### PR TITLE
Respect update_check_no_update_notify in update orphaning dashboard

### DIFF
--- a/reports/update-orphaning/Update orphaning analysis using longitudinal dataset.ipynb
+++ b/reports/update-orphaning/Update orphaning analysis using longitudinal dataset.ipynb
@@ -159,6 +159,7 @@
     "dataSubset = channelSubset.select(\"subsession_start_date\",\n",
     "                                  \"subsession_length\",\n",
     "                                  \"update_check_code_notify\",\n",
+    "                                  \"update_check_no_update_notify\",\n",
     "                                  \"build.version\",\n",
     "                                  \"settings.update.enabled\")"
    ]
@@ -295,7 +296,7 @@
    },
    "outputs": [],
    "source": [
-    "update_enabled_statuses = update_enabled_disabled_statuses.filter(lambda p: \"update-enabled\" in p)"
+    "update_enabled_statuses = update_enabled_disabled_statuses.filter(lambda p: \"update-enabled\" in p).cache()"
    ]
   },
   {
@@ -350,6 +351,8 @@
     "            counter += 1\n",
     "            if i != 0:\n",
     "                return counter\n",
+    "    if ping.update_check_no_update_notify is not None and ping.update_check_no_update_notify[0] > 0:\n",
+    "        return 0;\n",
     "    return -1\n",
     "\n",
     "update_check_code_notify_statuses = update_enabled_statuses.map(update_check_code_notify_mapper)\n",


### PR DESCRIPTION
We previously failed to check update_check_no_update_notify as a
possible state for orphaned users. This would mean that although
orphaned, users can’t see an update advertised and falsely believe that
no update is available.
